### PR TITLE
fix(PageableUtils): page number가 감소하지 않는 오류 해결

### DIFF
--- a/src/main/java/com/nineteen/omp/global/utils/PageableUtils.java
+++ b/src/main/java/com/nineteen/omp/global/utils/PageableUtils.java
@@ -11,12 +11,12 @@ public class PageableUtils {
 
   private static final int FIRST_PAGE = 1;
 
-  public static void validatePageable(Pageable pageable) {
+  public static Pageable validatePageable(Pageable pageable) {
     validatePageNumber(pageable.getPageNumber());
     validatePageSize(pageable.getPageSize());
     validateSortBy(pageable.getSort());
 
-    pageable.previousOrFirst();
+    return pageable.previousOrFirst();
   }
 
   private static void validatePageNumber(int pageNumber) {

--- a/src/test/java/com/nineteen/omp/global/utils/PageableUtilsTest.java
+++ b/src/test/java/com/nineteen/omp/global/utils/PageableUtilsTest.java
@@ -1,0 +1,21 @@
+package com.nineteen.omp.global.utils;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import org.junit.jupiter.api.Test;
+import org.springframework.data.domain.PageRequest;
+import org.springframework.data.domain.Pageable;
+import org.springframework.data.domain.Sort;
+
+class PageableUtilsTest {
+
+  @Test
+  void validatePageable() {
+    Pageable pageable = PageRequest.of(1, 10, Sort.by(Sort.Order.asc("updatedAt")));
+
+    pageable = pageable.previousOrFirst();
+
+    assertThat(pageable.getPageNumber()).isEqualTo(0);
+  }
+
+}


### PR DESCRIPTION
Pageable의 perviousOrFirst() 메서드는 해당 객체의 page number를 감소시키는 것이 아니라 감소된 새로운 Pageable 객체를 생성하므로 반환값 변경

# 💡 PR Summary - <!--{ 작업 내용 }-->
<!-- 어떤 작업에 대한 PR 인지 위 주석을 대신하여 적어주세요 -->


### PR 타입(하나 이상의 PR 타입을 선택해주세요)
- [ ] 기능 추가
- [ ] 기능 삭제
- [x] 버그 수정
- [ ] 의존성, 환경 변수, 빌드 관련 코드 업데이트
</br>

### 📝 Description

---
<!-- 어떤 작업을 했는지 간단하게 적어주세요 -->
작업 사항
</br>


</br>
### 📚 Etc

---
<!-- 작업 중 특이사항이 생기면 적어주세요 -->
특이사항

</br>
</br>
